### PR TITLE
Statsd telegraf role updated

### DIFF
--- a/ansible/roles/monitoring-statsd-fe-influxdb/defaults/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+influxdb_download_url_path_prefix: http://get.influxdb.org/telegraf

--- a/ansible/roles/monitoring-statsd-fe-influxdb/defaults/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-influxdb_download_url_path_prefix: http://get.influxdb.org/telegraf
+telegraf_download_url_path_prefix: http://get.influxdb.org/telegraf

--- a/ansible/roles/monitoring-statsd-fe-influxdb/handlers/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: restart telegraf
+  service: name=telegraf state=restarted
+  sudo: yes
+  tags:
+    - monitoring
+    - statsd
+    - statsd-fe-influxdb

--- a/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
@@ -9,7 +9,7 @@
     - statsd-fe-influxdb
 
 - name: Download telegraf package
-  get_url: url="http://get.influxdb.org/telegraf/telegraf_{{ telegraf_version }}_amd64.deb" dest="{{ monitoring_tmp_dir }}"
+  get_url: url="{{ telegraf_download_url_path_prefix }}/telegraf_{{ telegraf_version }}_amd64.deb" dest="{{ monitoring_tmp_dir }}"
   sudo: yes
   tags:
     - monitoring

--- a/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
@@ -26,7 +26,7 @@
     - statsd-fe-influxdb
 
 - name: Configure telegraf
-  template: src="telegraf.conf.j2" dest="/etc/telegraf/telegraf.conf"
+  template: src="telegraf.conf.j2" dest="/etc/opt/telegraf/telegraf.conf"
   sudo: yes
   notify: restart telegraf
   tags:

--- a/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
@@ -1,28 +1,37 @@
-- name: Stop statsd-fe-influxdb (if needed)
-  command: "docker stop statsd-fe-influxdb"
+- name: Create directories which need to exist if necessary
+  file: path={{ item }} state=directory owner=root
+  with_items:
+    - "{{ monitoring_tmp_dir }}"
   sudo: yes
-  ignore_errors: yes
   tags:
     - monitoring
     - statsd
     - statsd-fe-influxdb
 
-- name: Remove statsd-fe-influxdb (if there)
-  command: "docker rm statsd-fe-influxdb"
+- name: Download telegraf package
+  get_url: url="http://get.influxdb.org/telegraf/telegraf_{{ telegraf_version }}_amd64.deb" dest="{{ monitoring_tmp_dir }}"
   sudo: yes
-  ignore_errors: yes
   tags:
     - monitoring
     - statsd
     - statsd-fe-influxdb
 
-- name: Run statsd in front of influxdb for statsd collection
-  command: "docker run --name=statsd-fe-influxdb -p 9125:8125/udp -p 9126:8126 -d --restart=always -e IS_DEBUG_MODE=true -e TARGET_DB=metrics_db -e INFLUXDB_URL=\"\\\"http://{{ inventory_hostname }}:8086\\\"\"
-    -e USERNAME={{ statsd_influxdb_user }} -e PASSWORD={{ statsd_influxdb_passwd }} -e TELEGRAF_HOSTNAME={{ inventory_hostname }} {{ docker_registry }}/roger-telegraf-statsd:0.08"
+- name: Install telegraf
+  apt: deb="{{ monitoring_tmp_dir }}/telegraf_{{ telegraf_version }}_amd64.deb"
   sudo: yes
+  notify: restart telegraf
   tags:
     - monitoring
     - statsd
     - statsd-fe-influxdb
+
+- name: Configure telegraf
+  template: src="telegraf.conf.j2" dest="/etc/telegraf/telegraf.conf"
+  sudo: yes
+  notify: restart telegraf
+  tags:
+   - monitoring
+   - statsd
+   - statsd-fe-influxdb
 
 #TODO: Add/enable a probe so as to monitor this particular statsd instance and alert on failure

--- a/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
@@ -82,7 +82,7 @@
 # Statsd Server
 [statsd]
   # Address and port to host UDP listener on
-  service_address = ":9125"
+  service_address = ":{{ telegraf_port }}"
   # Delete gauges every interval (default=false)
   delete_gauges = false
   # Delete counters every interval (default=false)

--- a/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
@@ -82,7 +82,7 @@
 # Statsd Server
 [statsd]
   # Address and port to host UDP listener on
-  service_address = ":{{ telegraf_port }}"
+  service_address = ":{{ statsd_service_port }}"
   # Delete gauges every interval (default=false)
   delete_gauges = false
   # Delete counters every interval (default=false)

--- a/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.j2
@@ -1,0 +1,112 @@
+# Telegraf configuration
+
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared plugins.
+
+# Even if a plugin has no configuration, it must be declared in here
+# to be active. Declaring a plugin means just specifying the name
+# as a section with no variables. To deactivate a plugin, comment
+# out the name and any variables.
+
+# Use 'telegraf -config telegraf.toml -test' to see what metrics a config
+# file would generate.
+
+# One rule that plugins conform to is wherever a connection string
+# can be passed, the values '' and 'localhost' are treated specially.
+# They indicate to the plugin to use their own builtin configuration to
+# connect to the local system.
+
+# NOTE: The configuration has a few required parameters. They are marked
+# with 'required'. Be sure to edit those to make this configuration work.
+
+# Tags can also be specified via a normal map, but only one form at a time:
+[tags]
+  # dc = "us-east-1"
+
+# Configuration for telegraf agent
+[agent]
+  # Default data collection interval for all plugins
+  interval = "10s"
+  # Rounds collection interval to 'interval'
+  # ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  # Default data flushing interval for all outputs. You should not set this below
+  # interval. Maximum flush_interval will be flush_interval + flush_jitter
+  flush_interval = "10s"
+  # Jitter the flush interval by a random amount. This is primarily to avoid
+  # large write spikes for users running a large number of telegraf instances.
+  # ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  # Run telegraf in debug mode
+  debug = {{ debug_mode }}
+  # Override default hostname, if empty use os.Hostname()
+  hostname = "{{ inventory_hostname }}"
+
+
+###############################################################################
+#                                  OUTPUTS                                    #
+###############################################################################
+
+[outputs]
+
+# Configuration for influxdb server to send metrics to
+[outputs.influxdb]
+  # The full HTTP endpoint URL for your InfluxDB instance
+  # Multiple urls can be specified for InfluxDB cluster support.
+  urls = [ "http://{{ inventory_hostname }}:8086" ] # required
+  # The target database for metrics (telegraf will create it if not exists)
+  database = "{{ target_db }}" # required
+  # Precision of writes, valid values are n, u, ms, s, m, and h
+  # note: using second precision greatly helps InfluxDB compression
+  precision = "s"
+
+  # Connection timeout (for the connection with InfluxDB), formatted as a string.
+  # If not provided, will default to 0 (no timeout)
+  timeout = "5s"
+  username = "{{ statsd_influxdb_user }}"
+  password = "{{ statsd_influxdb_passwd }}"
+  # Set the user agent for the POSTs (can be useful for log differentiation)
+  # user_agent = "telegraf"
+
+###############################################################################
+#                                  PLUGINS                                    #
+###############################################################################
+
+
+###############################################################################
+#                              SERVICE PLUGINS                                #
+###############################################################################
+
+# Statsd Server
+[statsd]
+  # Address and port to host UDP listener on
+  service_address = ":9125"
+  # Delete gauges every interval (default=false)
+  delete_gauges = false
+  # Delete counters every interval (default=false)
+  delete_counters = false
+  # Delete sets every interval (default=false)
+  delete_sets = false
+  # Delete timings & histograms every interval (default=true)
+  delete_timings = true
+  # Percentiles to calculate for timing & histogram stats
+  percentiles = [90]
+
+  templates = [
+      "nsq.*.topic.*.channel.* app.host.measurement.topic_name.measurement.channel_name.measurement*",
+      "nsq.*.topic.* app.host.measurement.topic_name.measurement*",
+      "nsq.* app.host.measurement*",
+      "kairos.* app.env.measurement*",
+      "app.measurement*"
+  ]
+
+  # Number of UDP messages allowed to queue up, once filled,
+  # the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  # Number of timing/histogram values to track per-measurement in the
+  # calculation of percentiles. Raising this limit increases the accuracy
+  # of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000

--- a/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
@@ -6,4 +6,4 @@ target_db: "metrics_db"
 debug_mode: "true"
 
 #8125 has the actual stasd endpoint (repeaters). This is the port where the repeaters send the data to for each influxdb.
-telegraf_port: "9125"
+statsd_service_port: "9125"

--- a/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
-telegraf_version: "0.10.3-1"
+telegraf_version: "0.2.4"
 target_db: "metrics_db"
 debug_mode: "true"
 

--- a/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
@@ -1,0 +1,6 @@
+---
+
+monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
+telegraf_version: "0.10.3-1"
+target_db: "metrics_db"
+debug_mode: "true"

--- a/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
@@ -4,3 +4,6 @@ monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
 telegraf_version: "0.10.3-1"
 target_db: "metrics_db"
 debug_mode: "true"
+
+#8125 has the actual stasd endpoint (repeaters). This is the port where the repeaters send the data to for each influxdb.
+telegraf_port: "9125"


### PR DESCRIPTION
Now telegraf installation does not happen through docker. This will lead to monitoring-backend9 role not to be dependent on running the docker-machines role (from roger-mesos repo) before, as it no longer needs docker to be installed.

Ran this on my localcluster and things all look fine. Please note that the service_address has been updated to port 9125 and the configs are updated through jinja variable.

@ankanm and @jordmoz Please review. 
