### PR TITLE
Telegraf running under upstart

### DIFF
--- a/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/tasks/main.yml
@@ -34,4 +34,21 @@
    - statsd
    - statsd-fe-influxdb
 
+- name: Remove init.d script for telgraf
+  file: path=/etc/init.d/telegraf state=absent
+  sudo: yes
+  tags:
+    - monitoring
+    - statsd
+    - statsd-fe-influxdb
+
+- name: Install upstart script for telegraf
+  template: src=telegraf.conf.upstart.j2 dest=/etc/init/telegraf.conf
+  sudo: yes
+  notify: restart telegraf
+  tags:
+    - monitoring
+    - statsd
+    - statsd-fe-influxdb
+
 #TODO: Add/enable a probe so as to monitor this particular statsd instance and alert on failure

--- a/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.upstart.j2
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/templates/telegraf.conf.upstart.j2
@@ -1,0 +1,15 @@
+description     "Telegraf"
+
+limit nofile 65536 65536
+
+start on (net-device-up and local-filesystems and runlevel [2345])
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+
+console none
+setuid telegraf
+setgid telegraf
+
+exec /opt/telegraf/telegraf -pidfile /var/run/telegraf/telegraf.pid -config /etc/opt/telegraf/telegraf.conf -configdirectory /etc/opt/telegraf/telegraf.d

--- a/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
+++ b/ansible/roles/monitoring-statsd-fe-influxdb/vars/main.yml
@@ -3,7 +3,7 @@
 monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
 telegraf_version: "0.2.4"
 target_db: "metrics_db"
-debug_mode: "true"
+debug_mode: "false"
 
 #8125 has the actual stasd endpoint (repeaters). This is the port where the repeaters send the data to for each influxdb.
 statsd_service_port: "9125"


### PR DESCRIPTION
I updated telegraf on all the influx hosts to run now under Upstart. 
Deleted the old telegraf file : /var/log/telegraf/telegraf.log
After I confirmed, that telegraf connected with Influxdb correctly, I turned off the console to "none" (This is to avoid the parse errors happening from Moz-local metrics)

@ankanm and @jordmoz Please review.
