### PR TITLE
Added Incremental backup script for Influx

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repo contains everything you need to set up a monitoring system that can be used to monitor [roger-mesos](https://github.com/seomoz/roger-mesos) and tasks running on it.
 
+### Influxdb Restore
+* The influxdb role is set up to do incremental backups of the databases.
+* To do a restore of a database, here is an example:
+  ``` influxd restore -metadir <meta_dir_to_restore> -datadir <data_dir_to_restore> -database <database> <backup_dir>  ```
+
 #### Note
 * We are using git submodules in this repo. So, when cloning this repo ensure that you fetch submodules. Here's how:
   * When cloning a repo for the first time (for git version > 1.6.5):

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -60,6 +60,7 @@
     - "{{ influx_data_dir }}/plugin"
     - "{{ influx_data_dir }}/plugin/collectd"
     - "{{ influx_data_dir }}/backup"
+    - "{{ influx_data_dir }}/scripts"
     - "{{ influx_data_dir }}/wal"
   sudo: yes
   notify: restart influxdb9
@@ -121,13 +122,13 @@
 
 # Copy Influx backup script to influx hosts
 - name: Influx backup script to influx hosts
-  template: src=influxdb.backup.sh.j2  dest=/tmp/influxdb.backup.sh mode=0775
+  template: src=influxdb.backup.sh.j2  dest={{ influx_data_dir }}/scripts/influxdb.backup.sh mode=0775
   tags:
     - influx_backup
 
 # Running backup script as a cronjob on influx hosts
 - name: Running backup script as a cronjob on influx hosts
-  lineinfile: dest=/etc/crontab line="59 23  * * *   root    sh /tmp/influxdb.backup.sh"
+  lineinfile: dest=/etc/crontab line="59 23  * * *   root    sh {{ influx_data_dir }}/scripts/influxdb.backup.sh"
   sudo: yes
   tags:
     - influx_backup

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -59,6 +59,7 @@
     - "{{ influx_data_dir }}/meta"
     - "{{ influx_data_dir }}/plugin"
     - "{{ influx_data_dir }}/plugin/collectd"
+    - "{{ influx_data_dir }}/backup"
     - "{{ influx_data_dir }}/wal"
   sudo: yes
   notify: restart influxdb9
@@ -117,3 +118,16 @@
     - rm /tmp/influxdb.users.sh
   tags:
     - influx_users
+
+# Copy Influx backup script to influx hosts
+- name: Influx backup script to influx hosts
+  template: src=influxdb.backup.sh.j2  dest=/tmp/influxdb.backup.sh mode=0775
+  tags:
+    - influx_backup
+
+# Running backup script as a cronjob on influx hosts
+- name: Running backup script as a cronjob on influx hosts
+  lineinfile: dest=/etc/crontab line="59 23  * * *   root    sh /tmp/influxdb.backup.sh"
+  sudo: yes
+  tags:
+    - influx_backup

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -66,6 +66,7 @@
   notify: restart influxdb9
   tags:
     - monitoring
+    - influx_backup
 
 # Creating a concatenated types.db (as the influxdb collectd plugin currently does not support multiple typesdb file)
 - name: Create merged types.db for collectd plugin

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -126,11 +126,11 @@
 - name: Influx backup script to influx hosts
   template: src=influxdb.backup.sh.j2  dest={{ influx_data_dir }}/scripts/influxdb.backup.sh mode=0775
   tags:
-    - influx_backup
+    - influx_backp
 
 # Running backup script as a cronjob on influx hosts
 - name: Running backup script as a cronjob on influx hosts
-  cron: name="Backup script" minute="59" hour="23" user="root" job="bash {{ influx_data_dir }}/scripts/influxdb.backup.sh > {{ influx_data_dir }}/backup_logs/influx_backup.log"
+  cron: name="Backup script" minute="59" hour="23" user="root" job="bash {{ influx_data_dir }}/scripts/influxdb.backup.sh >> {{ influx_data_dir }}/backup_logs/influx_backup_$(date +\"%Y%m%d\").log"
   sudo: yes
   tags:
     - influx_backup

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -124,20 +124,20 @@
 
 # Copy Influx backup script to influx hosts
 - name: Influx backup script to influx hosts
-  template: src=influxdb.backup.sh.j2  dest=/tmp/influxdb.backup.sh mode=0775
+  template: src=influxdb.backup.sh.j2  dest={{ influx_data_dir }}/scripts/influxdb.backup.sh mode=0775
   tags:
     - influx_backup
 
 # Running backup script as a cronjob on influx hosts
 - name: Running backup script as a cronjob on influx hosts
-  lineinfile: dest=/etc/crontab line="59 23  * * *   root    bash {{ influx_data_dir }}/scripts/influxdb.backup.sh > {{ influx_data_dir }}/backup_logs/influx_backup.log"
+  cron: name="Backup script" minute="59" hour="23" user="root" job="bash {{ influx_data_dir }}/scripts/influxdb.backup.sh > {{ influx_data_dir }}/backup_logs/influx_backup.log"
   sudo: yes
   tags:
     - influx_backup
 
 # Remove backup timestamp file on Wednesday of every week. This will trigger a complete backup on Wednesday every week at 11:59am
 - name: Remove backup timestamp file on Wednesday of every week
-  lineinfile: dest=/etc/crontab line="59 11  * * 3   root    rm {{ influx_data_dir }}/backup/last_backup_timestamp"
+  cron: name="Remove backup timestamp" minute="59" hour="11" weekday="4" user="root" job="rm {{ influx_data_dir }}/backup/last_backup_timestamp"
   sudo: yes
   tags:
     - influx_backup

--- a/ansible/roles/monitoring-influxdb9/tasks/main.yml
+++ b/ansible/roles/monitoring-influxdb9/tasks/main.yml
@@ -60,6 +60,7 @@
     - "{{ influx_data_dir }}/plugin"
     - "{{ influx_data_dir }}/plugin/collectd"
     - "{{ influx_data_dir }}/backup"
+    - "{{ influx_data_dir }}/backup_logs"
     - "{{ influx_data_dir }}/scripts"
     - "{{ influx_data_dir }}/wal"
   sudo: yes
@@ -123,13 +124,20 @@
 
 # Copy Influx backup script to influx hosts
 - name: Influx backup script to influx hosts
-  template: src=influxdb.backup.sh.j2  dest={{ influx_data_dir }}/scripts/influxdb.backup.sh mode=0775
+  template: src=influxdb.backup.sh.j2  dest=/tmp/influxdb.backup.sh mode=0775
   tags:
     - influx_backup
 
 # Running backup script as a cronjob on influx hosts
 - name: Running backup script as a cronjob on influx hosts
-  lineinfile: dest=/etc/crontab line="59 23  * * *   root    sh {{ influx_data_dir }}/scripts/influxdb.backup.sh"
+  lineinfile: dest=/etc/crontab line="59 23  * * *   root    bash {{ influx_data_dir }}/scripts/influxdb.backup.sh > {{ influx_data_dir }}/backup_logs/influx_backup.log"
+  sudo: yes
+  tags:
+    - influx_backup
+
+# Remove backup timestamp file on Wednesday of every week. This will trigger a complete backup on Wednesday every week at 11:59am
+- name: Remove backup timestamp file on Wednesday of every week
+  lineinfile: dest=/etc/crontab line="59 11  * * 3   root    rm {{ influx_data_dir }}/backup/last_backup_timestamp"
   sudo: yes
   tags:
     - influx_backup

--- a/ansible/roles/monitoring-influxdb9/templates/influxdb.backup.sh.j2
+++ b/ansible/roles/monitoring-influxdb9/templates/influxdb.backup.sh.j2
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+TIME_NOW=$(date --rfc-3339=seconds | sed 's/ /T/')
+BACKUP_DIR="{{ influx_backup_dir }}"
+FILE="$BACKUP_DIR/last_backup_timestamp"
+DATABASES="{{ databases_to_backup }}"
+
+echo "Starting backup at $TIME_NOW."
+
+if [ -w "$FILE" ];
+then
+   LAST_TIMESTAMP=$(cat $FILE)
+   echo "Backup is being done since $LAST_TIMESTAMP"
+   for database in $DATABASES
+   do
+     $(influxd backup -database $database -since $LAST_TIMESTAMP $BACKUP_DIR)
+   done
+else
+   echo "File $FILE does not exist or is not writable. Doing a complete backup."
+   #Cleanup existing files in backup directory
+   files_exists=$( ls $BACKUP_DIR/ | wc -l )
+   if [ $files_exists != 0 ];
+   then
+     command="rm -f $BACKUP_DIR/*"
+     eval $command
+   fi
+
+   for database in $DATABASES
+   do
+     $(influxd backup -database $database $BACKUP_DIR)
+   done
+fi
+
+echo "Writing the new timestamp: $TIME_NOW to backup_timestamp file $FILE"
+echo "$TIME_NOW" > $FILE

--- a/ansible/roles/monitoring-influxdb9/templates/influxdb.backup.sh.j2
+++ b/ansible/roles/monitoring-influxdb9/templates/influxdb.backup.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TIME_NOW=$(date --rfc-3339=seconds | sed 's/ /T/')
-BACKUP_DIR="{{ influx_backup_dir }}"
+BACKUP_DIR="{{ influx_data_dir }}/backup"
 FILE="$BACKUP_DIR/last_backup_timestamp"
 DATABASES="{{ databases_to_backup }}"
 
@@ -13,10 +13,38 @@ then
    echo "Backup is being done since $LAST_TIMESTAMP"
    for database in $DATABASES
    do
-     $(influxd backup -database $database -since $LAST_TIMESTAMP $BACKUP_DIR)
+     $(influxd backup -database $database -since $LAST_TIMESTAMP $BACKUP_DIR 2>&1 | tee $BACKUP_DIR/$database.log)
+     backup_result=$(tail -1 $BACKUP_DIR/$database.log)
+     echo $backup_result
+     $(rm $BACKUP_DIR/$database.log)
+     if [[ "$backup_result" == *"backup complete"* ]];
+       then
+         echo "Backup for database $database is complete"
+       else
+         echo "Backup for database $database did not complete. Exiting."
+         exit
+     fi
    done
 else
    echo "File $FILE does not exist or is not writable. Doing a complete backup."
+   BACKUP_TMP_DIR=$(mktemp -d -p {{ influx_data_dir }})
+
+   for database in $DATABASES
+   do
+     $(influxd backup -database $database $BACKUP_TMP_DIR 2>&1 | tee $BACKUP_TMP_DIR/$database.log)
+     backup_result=$(tail -2 $BACKUP_TMP_DIR/$database.log)
+     echo $backup_result
+     $(rm $BACKUP_TMP_DIR/$database.log)
+     if [[ "$backup_result" == *"backup complete"* ]];
+       then
+         echo "Backup for database $database is complete"
+       else
+         echo "Backup for database $database did not complete. Deleting temp dir $BACKUP_TMP_DIR and exiting."
+         $(rm -rf $BACKUP_TMP_DIR)
+         exit
+     fi
+   done
+
    #Cleanup existing files in backup directory
    files_exists=$( ls $BACKUP_DIR/ | wc -l )
    if [ $files_exists != 0 ];
@@ -25,10 +53,12 @@ else
      eval $command
    fi
 
-   for database in $DATABASES
-   do
-     $(influxd backup -database $database $BACKUP_DIR)
-   done
+   echo "Copying backup data from temp dir $BACKUP_TMP_DIR to $BACKUP_DIR"
+   $(cp -rf $BACKUP_TMP_DIR/* $BACKUP_DIR/.)
+
+   echo "Backup successful. Deleting temporary backup dir: $BACKUP_TMP_DIR"
+   $(rm -rf $BACKUP_TMP_DIR)
+
 fi
 
 echo "Writing the new timestamp: $TIME_NOW to backup_timestamp file $FILE"

--- a/ansible/roles/monitoring-influxdb9/vars/main.yml
+++ b/ansible/roles/monitoring-influxdb9/vars/main.yml
@@ -2,7 +2,6 @@
 
 monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
 influx_data_dir: "{{ base_monitoring_dir }}/influxdb"
-influx_backup_dir: "{{ base_monitoring_dir }}/backup"
 
 influxdb_version: "0.10.1-1"
 

--- a/ansible/roles/monitoring-influxdb9/vars/main.yml
+++ b/ansible/roles/monitoring-influxdb9/vars/main.yml
@@ -2,6 +2,7 @@
 
 monitoring_tmp_dir: "{{ base_monitoring_dir }}/tmp"
 influx_data_dir: "{{ base_monitoring_dir }}/influxdb"
+influx_backup_dir: "{{ base_monitoring_dir }}/backup"
 
 influxdb_version: "0.10.1-1"
 


### PR DESCRIPTION
We are doing incremental backups of Influx database(s). The restore works fine with incremental backups. No matter how many incremental backups you take, one restore takes care of all of it.

Tested it out with: 
"influxd restore -metadir /data/monitoring/influxdb/meta/ -datadir /data/monitoring/influxdb/data/ -database metrics_db /tmp/backup"

Questions/Concerns:
1. The backup script runs as a cron job at 23:59 everyday. Should this be changed?
2. The backup script is currently getting copied to /tmp/influxdb.backup.sh. Should this be changed?

@ankanm and @jordmoz Please review.
