### PR TITLE
ROGER-1241 collect task allocations for cpu/mem/disk

### DIFF
--- a/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
+++ b/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
@@ -4,10 +4,10 @@ import collectd
 import json
 import requests
 
-MESOS_MASTER_HOST = "localhost"
+MESOS_MASTER_HOST = 'localhost'
 MESOS_MASTER_PORT = 5050
 VERBOSE_LOGGING = False
-MESOS_MASTER_URL = ""
+MESOS_MASTER_URL = ''
 
 def get_task_counts(master_url):
     """Return counts of all the tasks in various states"""

--- a/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
+++ b/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/python
 
 import collectd
 import json
@@ -10,6 +10,7 @@ VERBOSE_LOGGING = False
 MESOS_MASTER_URL = ""
 
 def get_task_counts(master_url):
+    """Return counts of all the tasks in various states"""
     url = '{}/metrics/snapshot'.format(master_url)
     resp = requests.get('{}'.format(url))
     resp_data = resp.json()
@@ -19,6 +20,7 @@ def get_task_counts(master_url):
     return counts
 
 def get_tasks(master_url):
+    """Return the a map of tasks to allocation data"""
     tasks = {}
     limit = int(sum(get_task_counts(master_url).values()))
     url = '{}/tasks?limit={}'.format(master_url, limit)
@@ -45,6 +47,7 @@ def configure_callback(conf):
     log_verbose('Configured with host=%s, port=%s, url=%s' % (MESOS_MASTER_HOST, MESOS_MASTER_PORT, MESOS_MASTER_URL))
 
 def read_callback():
+    """Read callback called"""
     log_verbose('Read callback called')
     tasks = get_tasks(MESOS_MASTER_URL)
     for taskid, allocations in tasks.items():
@@ -53,7 +56,7 @@ def read_callback():
         dispatch_stat(taskid, 'bytes', 'disk_allocation', allocations['disk'])
 
 def dispatch_stat(plugin_instance, type, type_instance, value):
-    #Read a key from info response data and dispatch a value
+    """Read a key from info response data and dispatch a value"""
     if value is None:
         collectd.warning('mesos-master-tasks plugin: Value not found for %s/%s' % (plugin_instance, type_instance))
         return

--- a/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
+++ b/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
@@ -42,7 +42,7 @@ def configure_callback(conf):
         else:
             collectd.warning('mesos master task plugin: Unknown config key: %s.' % node.key)
     MESOS_MASTER_URL = "http://" + MESOS_MASTER_HOST + ":" + str(MESOS_MASTER_PORT)
-    log_verbose('Configured with host=%s, port=%s, url=%s' % (MARATHON_HOST, MARATHON_PORT, MARATHON_URL))
+    log_verbose('Configured with host=%s, port=%s, url=%s' % (MESOS_MASTER_HOST, MESOS_MASTER_PORT, MESOS_MASTER_URL))
 
 def read_callback():
     log_verbose('Read callback called')

--- a/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
+++ b/ansible/roles/monitoring-agent/files/mesos-master-tasks.py
@@ -1,0 +1,78 @@
+#! /usr/bin/python
+
+import collectd
+import json
+import requests
+
+MESOS_MASTER_HOST = "localhost"
+MESOS_MASTER_PORT = 5050
+VERBOSE_LOGGING = False
+MESOS_MASTER_URL = ""
+
+def get_task_counts(master_url):
+    url = '{}/metrics/snapshot'.format(master_url)
+    resp = requests.get('{}'.format(url))
+    resp_data = resp.json()
+    counts = {}
+    for t in ['error', 'failed', 'finished', 'killed', 'lost', 'running', 'staging', 'starting']:
+        counts.update({ t: resp_data['master/tasks_{}'.format(t)] })
+    return counts
+
+def get_tasks(master_url):
+    tasks = {}
+    limit = int(sum(get_task_counts(master_url).values()))
+    url = '{}/tasks?limit={}'.format(master_url, limit)
+    resp = requests.get('{}'.format(url))
+    resp_data = resp.json()
+    for task in resp_data['tasks']:
+        if task['state'] == 'TASK_RUNNING':
+            tasks[task['id']] = { 'cpus': task['resources']['cpus'], 'mem': task['resources']['mem'], 'disk': task['resources']['disk'] }
+    return tasks
+
+def configure_callback(conf):
+    """Received configuration information"""
+    global MESOS_MASTER_HOST, MESOS_MASTER_PORT, MESOS_MASTER_URL, VERBOSE_LOGGING
+    for node in conf.children:
+        if node.key == 'Host':
+            MESOS_MASTER_HOST = node.values[0]
+        elif node.key == 'Port':
+            MESOS_MASTER_PORT = int(node.values[0])
+        elif node.key == 'Verbose':
+            VERBOSE_LOGGING = bool(node.values[0])
+        else:
+            collectd.warning('mesos master task plugin: Unknown config key: %s.' % node.key)
+    MESOS_MASTER_URL = "http://" + MESOS_MASTER_HOST + ":" + str(MESOS_MASTER_PORT)
+    log_verbose('Configured with host=%s, port=%s, url=%s' % (MARATHON_HOST, MARATHON_PORT, MARATHON_URL))
+
+def read_callback():
+    log_verbose('Read callback called')
+    tasks = get_tasks(MESOS_MASTER_URL)
+    for taskid, allocations in tasks.items():
+        dispatch_stat(taskid, 'percent', 'cpu_allocation', allocations['cpus'] * 100)
+        dispatch_stat(taskid, 'memory', 'mem_allocation', allocations['mem'])
+        dispatch_stat(taskid, 'bytes', 'disk_allocation', allocations['disk'])
+
+def dispatch_stat(plugin_instance, type, type_instance, value):
+    #Read a key from info response data and dispatch a value
+    if value is None:
+        collectd.warning('mesos-master-tasks plugin: Value not found for %s/%s' % (plugin_instance, type_instance))
+        return
+    log_verbose('Sending value[%s]: %s=%s' % (plugin_instance, type_instance, value))
+
+    val = collectd.Values(plugin='mesos-master-tasks')
+    val.plugin_instance = plugin_instance
+    val.type = type
+    val.type_instance = type_instance
+    val.values = [value]
+    # https://github.com/collectd/collectd/issues/716
+    val.meta = {'0': True}
+    val.dispatch()
+
+
+def log_verbose(msg):
+    if not VERBOSE_LOGGING:
+        return
+    collectd.info('mesos-master-tasks plugin [verbose]: %s' % msg)
+
+collectd.register_config(configure_callback)
+collectd.register_read(read_callback)

--- a/ansible/roles/monitoring-agent/tasks/main.yml
+++ b/ansible/roles/monitoring-agent/tasks/main.yml
@@ -133,7 +133,7 @@
 
 - name: Install zookeeper collectd by copying the python plugin
   copy: src=zk-collectd.py dest="{{ collectd_python_plugin_dir }}"
-  when: is_in_masters is defined
+  when: is_in_masters is defined and is_in_masters|bool
   become: yes
   notify: restart collectd
   tags:
@@ -141,7 +141,7 @@
     - monitor-zookeeper
 
 - name: Copy the required python plugin mesos_master file
-  when: is_in_masters is defined
+  when: is_in_masters is defined and is_in_masters|bool
   copy: src=mesos-master.py dest="{{ collectd_python_plugin_dir }}"
   become: yes
   notify: restart collectd
@@ -150,7 +150,7 @@
     - monitor-mesos
 
 - name: Copy the required python plugin mesos_master-tasks file
-  when: is_in_masters is defined
+  when: is_in_masters is defined and is_in_masters|bool
   copy: src=mesos-master-tasks.py dest="{{ collectd_python_plugin_dir }}"
   become: yes
   notify: restart collectd
@@ -159,7 +159,7 @@
     - monitor-mesos
 
 - name: Copy the required python plugin mesos_slave file
-  when: is_in_slaves is defined
+  when: is_in_slaves is defined and is_in_slaves|bool
   copy: src=mesos-slave.py dest="{{ collectd_python_plugin_dir }}"
   become: yes
   notify: restart collectd
@@ -169,7 +169,7 @@
 
 # for bamboo server status check
 - name: Copy the required python plugin bamboo status plugin file
-  when: is_in_bamboo_servers is defined
+  when: is_in_bamboo_servers is defined and is_in_bamboo_servers|bool
   copy: src=bamboo_status.py dest="{{ collectd_python_plugin_dir }}"
   become: yes
   notify: restart collectd
@@ -179,7 +179,7 @@
 
 # for bamboo server config-hash check
 - name: Copy the required python plugin bamboo config hash plugin file
-  when: is_in_bamboo_servers is defined
+  when: is_in_bamboo_servers is defined and is_in_bamboo_servers|bool
   copy: src=bamboo_confighash.py dest="{{ collectd_python_plugin_dir }}"
   become: yes
   notify: restart collectd
@@ -300,7 +300,7 @@
 
 - name: Install chronos collectd plugin
   copy: src=collectd-plugins/chronos/chronos.py dest="{{ collectd_python_plugin_dir }}"
-  when: is_in_masters is defined
+  when: is_in_masters is defined and is_in_masters|bool
   become: yes
   notify: restart collectd
   tags:

--- a/ansible/roles/monitoring-agent/tasks/main.yml
+++ b/ansible/roles/monitoring-agent/tasks/main.yml
@@ -149,6 +149,15 @@
     - monitoring
     - monitor-mesos
 
+- name: Copy the required python plugin mesos_master-tasks file
+  when: is_in_masters is defined
+  copy: src=mesos-master-tasks.py dest="{{ collectd_python_plugin_dir }}"
+  become: yes
+  notify: restart collectd
+  tags:
+    - monitoring
+    - monitor-mesos
+
 - name: Copy the required python plugin mesos_slave file
   when: is_in_slaves is defined
   copy: src=mesos-slave.py dest="{{ collectd_python_plugin_dir }}"

--- a/ansible/roles/monitoring-agent/templates/collectd.conf.j2
+++ b/ansible/roles/monitoring-agent/templates/collectd.conf.j2
@@ -80,6 +80,16 @@ Import "mesos-master"
 
 <Plugin "python">
 ModulePath "{{ collectd_python_plugin_dir }}"
+Import "mesos-master-tasks"
+  <Module "mesos-master-tasks">
+      Host {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+      Port 5050
+      Verbose false
+  </Module>
+</Plugin>
+
+<Plugin "python">
+ModulePath "{{ collectd_python_plugin_dir }}"
 Import "chronos"
   <Module "chronos">
       Host "{{ chronos_webui_host }}"


### PR DESCRIPTION
- We're now tracking cpu/mem/disk allocations per task.
  (The cpu allocation was missing from the grafana charts. Now we can add that as well.)
